### PR TITLE
Separate origin/destination subpoints

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -67,7 +67,8 @@ With reference to the test data in this repo, you can run the `jitter` command l
 ```{bash}
 odjitter --od-csv-path data/od.csv \
   --zones-path data/zones.geojson \
-  --subpoints-path data/road_network.geojson \
+  --subpoints-origins-path data/road_network.geojson \
+  --subpoints-destinations-path data/road_network.geojson \
   --max-per-od 50 --output-path output_max50.geojson
 ```
 
@@ -76,7 +77,8 @@ Try running it with a different `max-per-od` value (10 in the command below):
 ```{bash}
 odjitter --od-csv-path data/od.csv \
   --zones-path data/zones.geojson \
-  --subpoints-path data/road_network.geojson \
+  --subpoints-origins-path data/road_network.geojson \
+  --subpoints-destinations-path data/road_network.geojson \
   --max-per-od 10 --output-path output_max10.geojson
 ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,7 +176,8 @@ pub fn jitter<P: AsRef<Path>, W: Write>(
             destination_id,
         )?;
 
-        for _ in 0..repeat as usize {
+        // When repeat is 0, still preserve the row
+        for _ in 0..(repeat as usize).max(1) {
             loop {
                 let o = origin_sampler.sample(rng);
                 let d = destination_sampler.sample(rng);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -279,7 +279,7 @@ impl<'a> Subsampler<'a> {
     fn new(
         points_per_zone: &'a Option<BTreeMap<String, Vec<Point<f64>>>>,
         zone_polygon: &'a MultiPolygon<f64>,
-        zone_id: &String,
+        zone_id: &str,
     ) -> Result<Subsampler<'a>> {
         if let Some(points_per_zone) = points_per_zone {
             if let Some(points) = points_per_zone.get(zone_id) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,7 +118,7 @@ pub fn jitter<P: AsRef<Path>, W: Write>(
         // strings
         let string_map: HashMap<String, String> = rec?;
 
-        // How many times will we jitter this one row?
+        // How many times will we jitter this one row? This will be 0 if all_key is 0 for this row.
         let repeat = if let Some(all) = string_map
             .get(&options.all_key)
             .and_then(|all| all.parse::<f64>().ok())
@@ -139,9 +139,9 @@ pub fn jitter<P: AsRef<Path>, W: Write>(
                 // Never treat the origin/destination key as numeric
                 Value::String(value)
             } else if let Ok(x) = value.parse::<f64>() {
-                // Scale all of the numeric values
-                // TODO Crashes on NaNs, infinity
-                Value::Number(serde_json::Number::from_f64(x / repeat).unwrap())
+                // Scale all of the numeric values, unless all_key for this row is 0
+                let scaled = if repeat == 0.0 { x } else { x / repeat };
+                Value::Number(serde_json::Number::from_f64(scaled).unwrap())
             } else {
                 Value::String(value)
             };

--- a/src/scrape.rs
+++ b/src/scrape.rs
@@ -1,0 +1,76 @@
+use anyhow::Result;
+use geo_types::{Point, Polygon};
+use geojson::GeoJson;
+
+/// Extract all points from a GeoJSON file.
+///
+/// TODO: Note that the returned points are not deduplicated.
+pub fn scrape_points(path: &str) -> Result<Vec<Point<f64>>> {
+    let geojson_input = fs_err::read_to_string(path)?;
+    let geojson = geojson_input.parse::<GeoJson>()?;
+    let mut points = Vec::new();
+    if let GeoJson::FeatureCollection(collection) = geojson {
+        for feature in collection.features {
+            if let Some(geom) = feature.geometry {
+                points.extend(geometry_to_points(geom.try_into().unwrap()));
+            }
+        }
+    }
+    Ok(points)
+}
+
+fn geometry_to_points(geom: geo_types::Geometry<f64>) -> Vec<Point<f64>> {
+    let mut points = Vec::new();
+    // We can't use MapCoordsInplace
+    match geom {
+        geo_types::Geometry::Point(pt) => {
+            points.push(pt);
+        }
+        geo_types::Geometry::Line(line) => {
+            let (a, b) = line.points();
+            points.push(a);
+            points.push(b);
+        }
+        geo_types::Geometry::LineString(ls) => {
+            points.extend(ls.into_points());
+        }
+        geo_types::Geometry::Polygon(poly) => {
+            points.extend(polygon_to_points(poly));
+        }
+        geo_types::Geometry::MultiPoint(pts) => {
+            points.extend(pts);
+        }
+        geo_types::Geometry::MultiLineString(list) => {
+            for ls in list {
+                points.extend(ls.into_points());
+            }
+        }
+        geo_types::Geometry::MultiPolygon(list) => {
+            for poly in list {
+                points.extend(polygon_to_points(poly));
+            }
+        }
+        geo_types::Geometry::GeometryCollection(list) => {
+            for geom in list {
+                points.extend(geometry_to_points(geom));
+            }
+        }
+        geo_types::Geometry::Rect(rect) => {
+            points.extend(polygon_to_points(rect.to_polygon()));
+        }
+        geo_types::Geometry::Triangle(tri) => {
+            points.extend(polygon_to_points(tri.to_polygon()));
+        }
+    }
+    points
+}
+
+fn polygon_to_points(poly: Polygon<f64>) -> Vec<Point<f64>> {
+    let mut points = Vec::new();
+    let (exterior, interiors) = poly.into_inner();
+    points.extend(exterior.into_points());
+    for ls in interiors {
+        points.extend(ls.into_points());
+    }
+    points
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,3 +1,6 @@
+use std::collections::HashSet;
+
+use geo_types::Point;
 use geojson::GeoJson;
 use rand::rngs::StdRng;
 use rand::SeedableRng;
@@ -42,6 +45,61 @@ fn test_sums_match() {
     }
 }
 
+#[ignore]
+#[test]
+fn test_different_subpoints() {
+    let zones = load_zones("data/zones.geojson", "InterZone").unwrap();
+    let destination_subpoints = scrape_points("data/schools.geojson").unwrap();
+    // Keep a copy of the schools as a set
+    let schools: HashSet<_> = destination_subpoints.iter().map(hashify_point).collect();
+
+    let options = Options {
+        max_per_od: 1,
+        // TODO We need different strategies for origin and destination points
+        subsample: Subsample::UnweightedPoints(destination_subpoints),
+        // TODO od_schools.csv doesn't have this
+        all_key: "all".to_string(),
+        origin_key: "origin".to_string(),
+        destination_key: "destination".to_string(),
+        min_distance_meters: 1.0,
+    };
+    let mut rng = StdRng::seed_from_u64(42);
+    let mut raw_output = Vec::new();
+    jitter(
+        "data/od_schools.csv",
+        &zones,
+        &mut rng,
+        options,
+        &mut raw_output,
+    )
+    .unwrap();
+    let output = String::from_utf8(raw_output)
+        .unwrap()
+        .parse::<GeoJson>()
+        .unwrap();
+
+    // Verify that all destinations match one of the schools
+    if let GeoJson::FeatureCollection(fc) = output {
+        for feature in fc.features {
+            if let Some(geojson::Value::LineString(ls)) =
+                feature.geometry.as_ref().map(|geom| &geom.value)
+            {
+                let pt = ls.last().unwrap();
+                if !schools.contains(&hashify_point(&Point::new(pt[0], pt[1]))) {
+                    panic!(
+                        "An output feature doesn't end at a school subpoint: {:?}",
+                        feature
+                    );
+                }
+            } else {
+                panic!("Output geometry isn't a LineString: {:?}", feature.geometry);
+            }
+        }
+    } else {
+        panic!("Output isn't a FeatureCollection: {:?}", output);
+    }
+}
+
 // TODO Test zone names that look numeric and contain leading 0's
 
 fn sum_trips_input(csv_path: &str) -> f64 {
@@ -63,4 +121,9 @@ fn sum_trips_output(gj: &GeoJson) -> f64 {
         }
     }
     total
+}
+
+// Since f64 isn't hashable, just round to 3 decimal places for comparisons
+fn hashify_point(pt: &Point<f64>) -> Point<i64> {
+    Point::new((pt.x() * 1000.0) as i64, (pt.y() * 1000.0) as i64)
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -17,7 +17,8 @@ fn test_sums_match() {
         let subpoints = scrape_points("data/road_network.geojson").unwrap();
         let options = Options {
             max_per_od,
-            subsample: Subsample::UnweightedPoints(subpoints),
+            subsample_origin: Subsample::UnweightedPoints(subpoints.clone()),
+            subsample_destination: Subsample::UnweightedPoints(subpoints),
             all_key: "all".to_string(),
             origin_key: "geo_code1".to_string(),
             destination_key: "geo_code2".to_string(),
@@ -55,8 +56,8 @@ fn test_different_subpoints() {
 
     let options = Options {
         max_per_od: 1,
-        // TODO We need different strategies for origin and destination points
-        subsample: Subsample::UnweightedPoints(destination_subpoints),
+        subsample_origin: Subsample::RandomPoints,
+        subsample_destination: Subsample::UnweightedPoints(destination_subpoints),
         // TODO od_schools.csv doesn't have this
         all_key: "all".to_string(),
         origin_key: "origin".to_string(),


### PR DESCRIPTION
This splits the `--subpoints-path` flag into separate `--subpoints-origins-path` and `--subpoints-destinations-path` flags. If either one isn't specified, the tool falls back to picking random points instead.

No support for weighted subpoints yet; I'll do that separately. There was some other cleanup to do first, so this PR is already big