### PR TITLE
Support weighted subpoints #7

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,8 @@ odjitter --od-csv-path data/od_schools.csv \
   --subpoints-origins-path data/road_network.geojson \
   --subpoints-destinations-path data/schools.geojson \
   --disaggregation-key car \
-  --disaggregation-threshold 10 --output-path output_max10_schools.geojson
+  --disaggregation-threshold 10 \
+  --output-path output_max10_schools.geojson
 ```
 
 <div class="cell-output-stdout">
@@ -259,6 +260,38 @@ odjitter --od-csv-path data/od_schools.csv \
 
 </div>
 
+You can also set weights associated with each origin and destination in
+the input data. The following example weights trips to schools
+proportional to the values in the ‘weight’ key for each imaginary data
+point represented in the `schools.geojson` object:
+
+<div class="cell">
+
+``` bash
+./target/debug/odjitter --od-csv-path data/od_schools.csv \
+  --zones-path data/zones.geojson \
+  --origin-key origin \
+  --destination-key destination \
+  --subpoints-origins-path data/road_network.geojson \
+  --subpoints-destinations-path data/schools.geojson \
+  --disaggregation-key car \
+  --disaggregation-threshold 10 \
+  --weight-key-destinations weight \
+  --output-path output_max10_schools_with_weights.geojson
+```
+
+<div class="cell-output-stdout">
+
+    Scraped 7 zones from data/zones.geojson
+    Scraped 5073 subpoints from data/road_network.geojson
+    Scraped 31 subpoints from data/schools.geojson
+    Disaggregating OD data
+    Wrote output_max10_schools_with_weights.geojson
+
+</div>
+
+</div>
+
 # Details
 
 For full details on `odjitter`’s arguments run `odjitter --help` which
@@ -267,7 +300,7 @@ gives the following output:
 <div class="cell">
 
 ``` bash
-odjitter --help
+./target/debug/odjitter --help
 ```
 
 <div class="cell-output-stdout">
@@ -324,6 +357,16 @@ odjitter --help
 
         -V, --version
                 Print version information
+
+            --weight-key-destinations <WEIGHT_KEY_DESTINATIONS>
+                If specified, this column will be used to more frequently choose subpoints in
+                `subpoints_destinations_path` with a higher weight value. Otherwise all subpoints will
+                be equally likely to be chosen
+
+            --weight-key-origins <WEIGHT_KEY_ORIGINS>
+                If specified, this column will be used to more frequently choose subpoints in
+                `subpoints_origins_path` with a higher weight value. Otherwise all subpoints will be
+                equally likely to be chosen
 
             --zone-name-key <ZONE_NAME_KEY>
                 In the zones GeoJSON file, which property is the name of a zone [default: InterZone]

--- a/README.qmd
+++ b/README.qmd
@@ -123,7 +123,24 @@ odjitter --od-csv-path data/od_schools.csv \
   --subpoints-origins-path data/road_network.geojson \
   --subpoints-destinations-path data/schools.geojson \
   --disaggregation-key car \
-  --disaggregation-threshold 10 --output-path output_max10_schools.geojson
+  --disaggregation-threshold 10 \
+  --output-path output_max10_schools.geojson
+```
+
+You can also set weights associated with each origin and destination in the input data.
+The following example weights trips to schools proportional to the values in the 'weight' key for each imaginary data point represented in the `schools.geojson` object:
+
+```{bash}
+./target/debug/odjitter --od-csv-path data/od_schools.csv \
+  --zones-path data/zones.geojson \
+  --origin-key origin \
+  --destination-key destination \
+  --subpoints-origins-path data/road_network.geojson \
+  --subpoints-destinations-path data/schools.geojson \
+  --disaggregation-key car \
+  --disaggregation-threshold 10 \
+  --weight-key-destinations weight \
+  --output-path output_max10_schools_with_weights.geojson
 ```
 
 
@@ -132,7 +149,7 @@ odjitter --od-csv-path data/od_schools.csv \
 For full details on `odjitter`'s arguments run `odjitter --help` which gives the following output:
 
 ```{bash}
-odjitter --help
+./target/debug/odjitter --help
 ```
 
 # References

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,11 +23,21 @@ struct Args {
     /// specified, random points within each zone will be used instead.
     #[clap(long)]
     subpoints_origins_path: Option<String>,
+    /// If specified, this column will be used to more frequently choose subpoints in
+    /// `subpoints_origins_path` with a higher weight value. Otherwise all subpoints will be
+    /// equally likely to be chosen.
+    #[clap(long)]
+    weight_key_origins: Option<String>,
 
     /// The path to a GeoJSON file to use for sampling subpoints for destination zones. If this
     /// isn't specified, random points within each zone will be used instead.
     #[clap(long)]
     subpoints_destinations_path: Option<String>,
+    /// If specified, this column will be used to more frequently choose subpoints in
+    /// `subpoints_destinations_path` with a higher weight value. Otherwise all subpoints will be
+    /// equally likely to be chosen.
+    #[clap(long)]
+    weight_key_destinations: Option<String>,
 
     /// What's the maximum number of trips per output OD row that's allowed? If an input OD row
     /// contains less than this, it will appear in the output without transformation. Otherwise,
@@ -65,16 +75,16 @@ fn main() -> Result<()> {
     println!("Scraped {} zones from {}", zones.len(), args.zones_path);
 
     let subsample_origin = if let Some(ref path) = args.subpoints_origins_path {
-        let subpoints = odjitter::scrape_points(path)?;
+        let subpoints = odjitter::scrape_points(path, args.weight_key_origins)?;
         println!("Scraped {} subpoints from {}", subpoints.len(), path);
-        odjitter::Subsample::UnweightedPoints(subpoints)
+        odjitter::Subsample::WeightedPoints(subpoints)
     } else {
         odjitter::Subsample::RandomPoints
     };
     let subsample_destination = if let Some(ref path) = args.subpoints_destinations_path {
-        let subpoints = odjitter::scrape_points(path)?;
+        let subpoints = odjitter::scrape_points(path, args.weight_key_destinations)?;
         println!("Scraped {} subpoints from {}", subpoints.len(), path);
-        odjitter::Subsample::UnweightedPoints(subpoints)
+        odjitter::Subsample::WeightedPoints(subpoints)
     } else {
         odjitter::Subsample::RandomPoints
     };

--- a/src/scrape.rs
+++ b/src/scrape.rs
@@ -1,21 +1,37 @@
-use anyhow::Result;
+use anyhow::{bail, Result};
 use geo::coords_iter::CoordsIter;
-use geo_types::{Geometry, Point};
+use geo_types::Geometry;
 use geojson::GeoJson;
 
-/// Extract all points from a GeoJSON file.
+use crate::WeightedPoint;
+
+/// Extract all points from a GeoJSON file. If `weight_key` is specified, use this numeric property
+/// per feature as a relative weight for the point. If unspecified, every point will be equally
+/// weighted.
 ///
 /// TODO: Note that the returned points are not deduplicated.
-pub fn scrape_points(path: &str) -> Result<Vec<Point<f64>>> {
+pub fn scrape_points(path: &str, weight_key: Option<String>) -> Result<Vec<WeightedPoint>> {
     let geojson_input = fs_err::read_to_string(path)?;
     let geojson = geojson_input.parse::<GeoJson>()?;
     let mut points = Vec::new();
     if let GeoJson::FeatureCollection(collection) = geojson {
         for feature in collection.features {
+            let weight = if let Some(ref key) = weight_key {
+                if let Some(weight) = feature.property(key).and_then(|x| x.as_f64()) {
+                    weight
+                } else {
+                    bail!("Feature doesn't have a numeric {} key: {:?}", key, feature);
+                }
+            } else {
+                1.0
+            };
             if let Some(geom) = feature.geometry {
                 let geom: Geometry<f64> = geom.try_into()?;
                 for pt in geom.coords_iter() {
-                    points.push(pt.into());
+                    points.push(WeightedPoint {
+                        point: pt.into(),
+                        weight,
+                    });
                 }
             }
         }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -14,11 +14,11 @@ fn test_sums_match() {
     let input_sums = sum_trips_input("data/od.csv", &["all", "car_driver", "foot"]);
 
     for disaggregation_threshold in [1, 10, 100, 1000] {
-        let subpoints = scrape_points("data/road_network.geojson").unwrap();
+        let subpoints = scrape_points("data/road_network.geojson", None).unwrap();
         let options = Options {
             disaggregation_threshold,
-            subsample_origin: Subsample::UnweightedPoints(subpoints.clone()),
-            subsample_destination: Subsample::UnweightedPoints(subpoints),
+            subsample_origin: Subsample::WeightedPoints(subpoints.clone()),
+            subsample_destination: Subsample::WeightedPoints(subpoints),
             disaggregation_key: "all".to_string(),
             origin_key: "geo_code1".to_string(),
             destination_key: "geo_code2".to_string(),
@@ -51,14 +51,18 @@ fn test_sums_match() {
 #[test]
 fn test_different_subpoints() {
     let zones = load_zones("data/zones.geojson", "InterZone").unwrap();
-    let destination_subpoints = scrape_points("data/schools.geojson").unwrap();
+    let destination_subpoints =
+        scrape_points("data/schools.geojson", Some("weight".to_string())).unwrap();
     // Keep a copy of the schools as a set
-    let schools: HashSet<_> = destination_subpoints.iter().map(hashify_point).collect();
+    let schools: HashSet<_> = destination_subpoints
+        .iter()
+        .map(|pt| hashify_point(&pt.point))
+        .collect();
 
     let options = Options {
         disaggregation_threshold: 1,
         subsample_origin: Subsample::RandomPoints,
-        subsample_destination: Subsample::UnweightedPoints(destination_subpoints),
+        subsample_destination: Subsample::WeightedPoints(destination_subpoints),
         disaggregation_key: "walk".to_string(),
         origin_key: "origin".to_string(),
         destination_key: "destination".to_string(),


### PR DESCRIPTION
Adds flags `--weight-key-destinations` and `--weight-key-origins`. I haven't tested this manually with the schools dataset or figured out how to sanely unit test it (fix the RNG seed and plug in a very high weight for one school and tiny for the others?). So up to you if we proceed, or if you have some idea for validation