### PR TITLE
Optionally guarantee output pairs are unique. #38

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -333,9 +333,19 @@ dependencies = [
  "geo",
  "geo-types",
  "geojson",
+ "ordered-float",
  "rand",
  "rstar",
  "serde_json",
+]
+
+[[package]]
+name = "ordered-float"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d84eb1409416d254e4a9c8fa56cc24701755025b458f0fcd8e59e1f5f40c23bf"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ fs-err = "2.6.0"
 geo = "0.18.0"
 geo-types = "0.7.2"
 geojson = { version = "0.22.2", features = ["geo-types"] }
+ordered-float = "3.4.0"
 rand = "0.8.4"
 rstar = "0.8.4"
 serde_json = "1.0.73"

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,6 +88,11 @@ struct CommonArgs {
     /// Guarantee that jittered origin and destination points are at least this distance apart.
     #[clap(long, default_value = "1.0")]
     min_distance_meters: f64,
+    /// Prevent duplicate (origin, destination) pairs from appearing in the output. This may
+    /// increase memory and runtime requirements. Note the duplication uses the floating point
+    /// precision of the input data, and only consider geometry (not any properties).
+    #[clap(long)]
+    deduplicate_pairs: bool,
 }
 
 fn main() -> Result<()> {
@@ -122,6 +127,7 @@ fn main() -> Result<()> {
         origin_key: common.origin_key,
         destination_key: common.destination_key,
         min_distance_meters: common.min_distance_meters,
+        deduplicate_pairs: common.deduplicate_pairs,
     };
     let mut rng = if let Some(seed) = common.rng_seed {
         StdRng::seed_from_u64(seed)


### PR DESCRIPTION
This adds a new flag `--deduplicate-pairs`, disabled by default. I have not tested memory/runtime impacts on "real" datasets, but can iterate if your use case gets much worse.

Echoing a question from the issue: Do we want to deduplicate just based on the two points, or do the other keys/properties matter too? ie, is this allowed in the output or not?

```
[{origin: [0, 0], destination: [1, 1], mode: bike},
{origin: [0, 0], destination: [1, 1], mode: drive}]
```